### PR TITLE
update: cart Dockerfile 수정

### DIFF
--- a/cart-cna-microservice/Dockerfile
+++ b/cart-cna-microservice/Dockerfile
@@ -1,7 +1,6 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-jdk
 ARG APP_HOME=/app
 WORKDIR ${APP_HOME}
-RUN apk add --no-cache findutils
 COPY gradlew .
 COPY gradle gradle
 COPY settings.gradle .


### PR DESCRIPTION
## Fixed
- openjdk:17-alpine 을 찾을 수 없는 문제 발생하여 이미지 변경
- Debian 기반으로 만들어진 이미지인 eclipse-temurin:17-jdk 에 findutils 패키지가 기본적으로 설치되어 있어서 설치할 필요 없으니 findutils를 설치하는 코드 삭제